### PR TITLE
Add an option to configure FAKELAG_CONFIGURABLE at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Role Variables
 |   unreal_curl_dir  | string |          /usr         |             Location where curl libs are installed             |
 |   unreal_ssl_dir   | string |                       |              SSL key directory, empty by default.              |
 |   unreal_modules   | array  |    [ 'auditorium' ]   |              Array of 3rd party modules to install             |
+| unreal_fakelag_configurable | boolean | False       | Set the [FAKELAG_CONFIGURABLE](https://www.unrealircd.org/docs/FAQ#Why_is_UnrealIRCd_responding_slowly_.28laggy.29._It.27s_only_processing_1_line_per_second.3F.3F) parameter in config.h        |
 |   enable_services | boolean | False | Enabels Atheme services to be installed on one or more hosts |
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ unreal_remote_conf: 1
 unreal_curl_dir: /usr
 unreal_ssl_dir: ''
 unreal_modules: [ 'auditorium', 'listrestrict', 'showwebirc', 'clones', 'kickjoindelay' ]
+unreal_fakelag_configurable: false
 
 # Generally override on a per-host basis
 enable_services: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,15 @@
     src: config_settings.j2
     dest: "{{ unreal_build_dir }}/unrealircd-{{ unreal_version }}/config.settings"
 
+- name: Configure Fakelag
+  become: yes
+  become_user: "{{ irc_user }}"
+  lineinfile:
+    path: "{{ unreal_build_dir }}/unrealircd-{{ unreal_version }}/include/config.h"
+    line: "#define FAKELAG_CONFIGURABLE"
+    regexp: "^(//)?#(undef|define) FAKELAG_CONFIGURABLE"
+  when: unreal_fakelag_configurable
+  
 - name: Create Makefile
   become: yes
   become_user: "{{ irc_user }}"


### PR DESCRIPTION
This adds a variable unreal_fakelag_configurable, set to False by default (so we keep the current behaviour, and be reasonnable about that setting), that allows to have bots flooding without giving them any IRCop privilege.

Doc for the setting is here: https://www.unrealircd.org/docs/FAQ#Why_is_UnrealIRCd_responding_slowly_.28laggy.29._It.27s_only_processing_1_line_per_second.3F.3F